### PR TITLE
Add Multiline comment support 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Suggests:
     rapidoc,
     sf,
     lubridate
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Collate:
     'async.R'
     'content-types.R'

--- a/R/options_plumber.R
+++ b/R/options_plumber.R
@@ -47,9 +47,10 @@
 #' will not interpret e.g. plot_width and plot_height parameters as plot image
 #' size instructions}
 #' }
+#' \item{`plumber.verboseParsing`}{Plumber will output line-by-line messages during parsing.}
 #'
 #' @param ... Ignored. Should be empty
-#' @param port,docs,docs.callback,trailingSlash,methodNotAllowed,apiScheme,apiHost,apiPort,apiPath,apiURL,maxRequestSize,sharedSecret,legacyRedirects,typedParameters,staticSerializers See details
+#' @param port,docs,docs.callback,trailingSlash,methodNotAllowed,apiScheme,apiHost,apiPort,apiPath,apiURL,maxRequestSize,sharedSecret,legacyRedirects,typedParameters,staticSerializers,verboseParsing See details
 #' @return
 #' The complete, prior set of [options()] values.
 #' If a particular parameter is not supplied, it will return the current value.
@@ -71,7 +72,8 @@ options_plumber <- function(
   sharedSecret         = getOption("plumber.sharedSecret"),
   legacyRedirects      = getOption("plumber.legacyRedirects"),
   typedParameters      = getOption("plumber.typedParameters"),
-  staticSerializers    = getOption("plumber.staticSerializers")
+  staticSerializers    = getOption("plumber.staticSerializers"),
+  verboseParsing       = getOption("plumber.verboseParsing")
 ) {
   ellipsis::check_dots_empty()
 
@@ -95,6 +97,7 @@ options_plumber <- function(
     plumber.sharedSecret         =   sharedSecret,
     plumber.legacyRedirects      =   legacyRedirects,
     plumber.typedParameters      =   typedParameters,
-    plumber.staticSerializers    =   staticSerializers
+    plumber.staticSerializers    =   staticSerializers,
+    plumber.verboseParsing       =   verboseParsing
   )
 }

--- a/R/plumb-block.R
+++ b/R/plumb-block.R
@@ -30,13 +30,14 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
   props <- NULL
   requestBodyObjectName <- NULL
 
-  verbose_line_building <- TRUE
+  verboseParsing <- getOption("plumber.verboseParsing", default="FALSE") == "TRUE"
+
   line_carryover <- character()
 
   while (lineNum > 0 && (stri_detect_regex(file[lineNum], pattern="^#['\\*]?|^\\s*$") || stri_trim_both(file[lineNum]) == "")){
 
     line <- file[lineNum]
-    if (verbose_line_building) message("*** line seen: ", line)
+    if (verboseParsing) message("*** line seen: ", line)
 
     # If the line does not start with a plumber tag `#*` or `#'`, continue to next line
     if (!stri_detect_regex(line, pattern="^#['\\*]")) {
@@ -55,9 +56,9 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
       if (length(line_carryover) > 0 &&
           stringi::stri_length(line) == 0) {
         line <- "\n"
-        if (verbose_line_building) message("*** lineend added to carryover")
+        if (verboseParsing) message("*** lineend added to carryover")
       } else {
-        if (verbose_line_building) message("*** carryover added to ", line)
+        if (verboseParsing) message("*** carryover added to ", line)
       }
       line_carryover <- c(line, line_carryover)
       lineNum <- lineNum - 1
@@ -67,7 +68,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
     line <- c(line, line_carryover)
     line_carryover <- character()
     line <- paste(line, collapse = "\n")
-    if (verbose_line_building) message("*** line for processing: ", line)
+    if (verboseParsing) message("*** line for processing: ", line)
 
     epMat <- stri_match(line, regex="^#['\\*]\\s*@(get|put|post|use|delete|head|options|patch)(\\s+(.*)$)?")
     if (!is.na(epMat[1,2])){

--- a/R/plumb-block.R
+++ b/R/plumb-block.R
@@ -38,7 +38,6 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
     line <- file[lineNum]
     if (verbose_line_building) message("*** line seen: ", line)
 
-
     # If the line does not start with a plumber tag `#*` or `#'`, continue to next line
     if (!stri_detect_regex(line, pattern="^#['\\*]")) {
       lineNum <- lineNum - 1
@@ -67,7 +66,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
 
     line <- c(line, line_carryover)
     line_carryover <- character()
-    line <- paste(line, collapse = " ")
+    line <- paste(line, collapse = "\n")
     if (verbose_line_building) message("*** line for processing: ", line)
 
     epMat <- stri_match(line, regex="^#['\\*]\\s*@(get|put|post|use|delete|head|options|patch)(\\s+(.*)$)?")
@@ -232,7 +231,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
 
     # testing: line <- "#* @response 200 Just a description"
     # line <- "#* @response 200 @body AThing Just a description"
-    responseMat <- stri_match(line, regex="^#['\\*]\\s*@response\\s+(\\w+)(?:\\s+@body\\s+([^\\s]*))?\\s+(\\S.*)\\s*$")
+    responseMat <- stri_match(line, regex="(?s)^#['\\*]\\s*@response\\s+(\\w+)(?:\\s+@body\\s+([^\\s]*))?\\s+(\\S.*)\\s*")
     if (!is.na(responseMat[1,1])){
       resp <- list()
       resp[[responseMat[1,2]]] <- list(
@@ -246,7 +245,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
       responses <- c(responses, resp)
     }
 
-    paramMat <- stri_match(line, regex="^#['\\*]\\s*@param(\\s+([^\\s:]+):?([^\\s*]+)?(\\*)?(?:\\s+(.*))?\\s*$)?")
+    paramMat <- stri_match(line, regex="(?s)^#['\\*]\\s*@param(\\s+([^\\s:]+):?([^\\s*]+)?(\\*)?(?:\\s+(.*))?\\s*)?")
     if (!is.na(paramMat[1,2])){
       name <- paramMat[1,3]
       if (is.na(name)){
@@ -261,7 +260,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
       params[[name]] <- list(desc=paramMat[1,6], type=apiType, required=required, isArray=isArray)
     }
 
-    tagMat <- stri_match(line, regex="^#['\\*]\\s*@tag\\s+(\"[^\"]+\"|'[^']+'|\\S+)\\s*")
+    tagMat <- stri_match(line, regex="(?s)^#['\\*]\\s*@tag\\s+(\"[^\"]+\"|'[^']+'|\\S+)\\s*")
     if (!is.na(tagMat[1,1])){
       t <- stri_trim_both(tagMat[1,2], pattern = "[[\\P{Wspace}]-[\"']]")
       if (is.na(t) || t == ""){
@@ -273,18 +272,13 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
       tags <- c(tags, t)
     }
 
-    commentMat <- stri_match(line, regex="^#['\\*]\\s*([^@\\s].*$)")
-    if (!is.na(commentMat[1,2])){
-      comments <- c(comments, trimws(commentMat[1,2]))
-    }
-
     routerModifierMat <- stri_match(line, regex="^#['\\*]\\s*@plumber")
     if (!is.na(routerModifierMat[1,1])) {
       routerModifier <- TRUE
     }
 
     # example: line <- "#* @requestBody life"
-    requestBodyMat <- stri_match(line, regex="^#['\\*]\\s*@requestBody\\s*(.*)\\s*$")
+    requestBodyMat <- stri_match(line, regex="(?s)^#['\\*]\\s*@requestBody\\s*(.*)\\s*")
     if (!is.na(requestBodyMat[1,1])){
       rb <- stri_trim_both(requestBodyMat[1,2])
 
@@ -300,7 +294,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
       requestBodyObjectName <- rb
     }
 
-    objectMat <- stri_match(line, regex="^#['\\*]\\s*@schema(\\s+(.*)$)?$")
+    objectMat <- stri_match(line, regex="^#['\\*]\\s*@schema(\\s+(.*)$)?")
     if (!is.na(objectMat[1,1])){
       o <- stri_trim_both(objectMat[1,3])
 
@@ -321,7 +315,7 @@ plumbBlock <- function(lineNum, file, envir = parent.frame()){
     # testing line <- "#* @prop One:[string] The Description"
     # testing line <- "#* @prop One:[object]:foo The Description"
     # testing line <- "#* @prop One:[object]:foo* The Description"
-    propMat <- stri_match(line, regex="^#['\\*]\\s*@prop(\\s+([^\\s:]+):?([^[\\s:]*]+)?(?::([^\\s*]+))?(\\*)?(?:\\s+(.*))?\\s*$)?")
+    propMat <- stri_match(line, regex="(?s)^#['\\*]\\s*@prop(\\s+([^\\s:]+):?([^[\\s:]*]+)?(?::([^\\s*]+))?(\\*)?(?:\\s+(.*))?\\s*)?")
     if (!is.na(propMat[1,2])){
       name <- propMat[1,3]
       if (is.na(name)){
@@ -391,7 +385,7 @@ evaluateBlock <- function(srcref, file, expr, envir, addEndpoint, addFilter, add
         !is.null(block$routerModifier),
         !is.null(block$object)) > 1){
     stopOnLine(lineNum, file[lineNum],
-               paste0("A single function can only be a filter, an API endpoint, ", 
+               paste0("A single function can only be a filter, an API endpoint, ",
                "an asset, an object or a Plumber object modifier (@filter AND @get, ",
                "@post, @assets, @plumber, etc.)"))
   }

--- a/R/plumb-globals.R
+++ b/R/plumb-globals.R
@@ -79,7 +79,7 @@ plumbGlobals <- function(lines, envir = parent.frame()){
     if (length(parsedLine) == 4){
       if (nchar(parsedLine[3]) == 0){
         # Not a new argument, continue existing one
-        fullArg <- paste(fullArg, parsedLine[4])
+        fullArg <- paste(fullArg, parsedLine[4], sep="\n")
       } else {
         # New argument, parse the buffer and start a new one
         fields <- plumbOneGlobal(fields, fullArg, envir)

--- a/R/plumb-globals.R
+++ b/R/plumb-globals.R
@@ -18,6 +18,11 @@ plumbOneGlobal <- function(fields, argument, envir = parent.frame()){
     return(fields)
   }
 
+  verboseParsing <- getOption("plumber.verboseParsing", default="FALSE") == "TRUE"
+  if (verboseParsing) {
+    message("*** Parsing global from ", argument)
+  }
+
   name <- parsedLine[3]
   def <- parsedLine[4]
   def <- gsub("^\\s*|\\s*$", "", def)

--- a/man/PlumberEndpoint.Rd
+++ b/man/PlumberEndpoint.Rd
@@ -189,6 +189,8 @@ parsers = c("json", "form", "text", "octet", "multi")
 
 \item{\code{comments, description, responses, tags}}{Values to be used within the OpenAPI Spec}
 
+\item{\code{requestBodyObjectName}}{schema name for object used in endpoint request body}
+
 \item{\code{srcref}}{\code{srcref} attribute from block}
 }
 \if{html}{\out{</div>}}

--- a/man/options_plumber.Rd
+++ b/man/options_plumber.Rd
@@ -20,13 +20,14 @@ options_plumber(
   sharedSecret = getOption("plumber.sharedSecret"),
   legacyRedirects = getOption("plumber.legacyRedirects"),
   typedParameters = getOption("plumber.typedParameters"),
-  staticSerializers = getOption("plumber.staticSerializers")
+  staticSerializers = getOption("plumber.staticSerializers"),
+  verboseParsing = getOption("plumber.verboseParsing")
 )
 }
 \arguments{
 \item{...}{Ignored. Should be empty}
 
-\item{port, docs, docs.callback, trailingSlash, methodNotAllowed, apiScheme, apiHost, apiPort, apiPath, apiURL, maxRequestSize, sharedSecret, legacyRedirects, typedParameters, staticSerializers}{See details}
+\item{port, docs, docs.callback, trailingSlash, methodNotAllowed, apiScheme, apiHost, apiPort, apiPath, apiURL, maxRequestSize, sharedSecret, legacyRedirects, typedParameters, staticSerializers, verboseParsing}{See details}
 }
 \value{
 The complete, prior set of \code{\link[=options]{options()}} values.
@@ -82,4 +83,5 @@ supplied type hints.  Defaults to\code{TRUE}}
 will not interpret e.g. plot_width and plot_height parameters as plot image
 size instructions}
 }
+\item{\code{plumber.verboseParsing}}{Plumber will output line-by-line messages during parsing.}
 }


### PR DESCRIPTION
Support for multiline params too - e.g. this code:

```
#* @apiTitle Plumber Example API
#* @apiDescription Plumber example description.
#*
#* Some more text about this...

#* Post a dataset to a pin
#*
#* The file contents will be uploaded to a pin named:
#*    _pin_account_/{pin_folder}_{name}
#*
#* The API will assign a vanity url to the pin of:
#*    {vanity_folder}/{name}
#*
#* Note that the "multi" parser parsing here is fairly "magic" - it automatically
#* parses the incoming csv/json/rds/parquet ready for the pins api
#* In some ways I wish it wouldn't - would be better to use a binary blob...
#* However, the pins API prefers an R object (list or tibble) at present
#* See https://github.com/rstudio/pins-r/issues/803
#*
#* @param type:string The type of data in the pin - one of "csv",
#*  "json", "parquet" or "rds"
#* @param pin_folder:string The pin folder to post to
#* @param vanity_folder:string The vanity url base folder for the pin
#* @param name:string The pin name to post
#* @param viewer_groups:[string] The viewer (reader) groups to allow access
#* to the pin - e.g. "Marketing".
#*
#* Note that "IT Admins" will always be added anyway.
#* @param viewer_users:[string] The individual viewer (reader) users to
#* allow access to the ping - e.g. "stuart@myco.com"
#* @param contents:file The dataset to use for the pin contents
#* @parser multi
#* @parser csv
#* @parser json
#* @parser rds
#* @parser parquet
#* @post /upload_dataset
function(contents, type, pin_folder, vanity_folder, name, viewer_groups = character(), viewer_users = character()) {
  # TODO logic
}
```
renders as:
![image](https://github.com/slodge/plumber/assets/533662/264d4acd-069a-4143-b8b8-d13a8ec607cd)
